### PR TITLE
Fix memory compression

### DIFF
--- a/sequence_test.go
+++ b/sequence_test.go
@@ -2,9 +2,8 @@ package gnlp_test
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/shota3506/gnlp"
+	"testing"
 )
 
 func TestLongestCommonSubsequence(t *testing.T) {


### PR DESCRIPTION
before
```
BenchmarkUniqueSequences
BenchmarkUniqueSequences/size=10
BenchmarkUniqueSequences/size=10-10         	   81054	     12981 ns/op	   25184 B/op	     336 allocs/op
BenchmarkUniqueSequences/size=100
BenchmarkUniqueSequences/size=100-10        	     421	   2840320 ns/op	 7675257 B/op	   32806 allocs/op
BenchmarkUniqueSequences/size=1000
BenchmarkUniqueSequences/size=1000-10       	       2	 622543250 ns/op	4589146744 B/op	 3047978 allocs/op
```

after
```
BenchmarkUniqueSequences
BenchmarkUniqueSequences/size=10
BenchmarkUniqueSequences/size=10-10         	   94696	     12663 ns/op	   22256 B/op	     334 allocs/op
BenchmarkUniqueSequences/size=100
BenchmarkUniqueSequences/size=100-10        	     771	   1555909 ns/op	 2362612 B/op	   30670 allocs/op
BenchmarkUniqueSequences/size=1000
BenchmarkUniqueSequences/size=1000-10       	       8	 142747307 ns/op	241299422 B/op	 3010611 allocs/op
```


using this benchmark
```
func BenchmarkUniqueSequences(b *testing.B) {
	for _, size := range []int{10, 100, 1000} {
		ss := make([][]int, size)
		for i := 0; i < size; i++ {
			ss[i] = make([]int, size)
			for j := 0; j < size; j++ {
				ss[i][j] = rand.Intn(size)
			}
		}
		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
			b.ReportAllocs()
			for i := 0; i < b.N; i++ {
				_ = uniqueSequences1(ss)
			}
		})
	}
}
```